### PR TITLE
fixed starting player mismatch

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,8 +14,11 @@ After that, it's the next player's turn
 let scores = [0, 0];
 let roundScore = 0;
 
-// The active player will be our player 1 and the player with a value of 1 will be our second player.
-let activePlayer = 1;
+// The active player will be our Player 1 and the player with a value of 1 will be our second player.
+let activePlayer = 0;
+
+// Add active indicator to the panel of the starting player
+document.querySelector(`.player-${activePlayer}-panel`).classList.add('active')
 
 let dice = Math.floor(Math.random() * 6) + 1;
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
     <body>
         <div class="wrapper clearfix">
-            <div class="player-0-panel active">
+            <div class="player-0-panel">
                 <div class="player-name" id="name-0">Player 1</div>
                 <div class="player-score" id="score-0">43</div>
                 <div class="player-current-box">


### PR DESCRIPTION
This commit fixes the mismatch between starting player set in the HTML and the starting player set in the JavaScript. This also allows you to freely change the value of the `activePlayer` variable, which might be helpful if you would like to implement multiple turns  (_best of 3_, _best of 5_ modes for example).